### PR TITLE
JeonghakLee / 4월 1주차

### DIFF
--- a/JeonghakLee/Solution_17255_N으로만들기.java
+++ b/JeonghakLee/Solution_17255_N으로만들기.java
@@ -1,0 +1,44 @@
+package baekjoon;
+
+import java.util.HashSet;
+import java.util.Scanner;
+import java.util.Set;
+
+public class Solution_17255_N으로만들기 {
+
+	static char[] nums;
+	static int answer, numLen;
+	static Set<String> promiseSet;
+
+	public static void main(String[] args) throws Exception {
+		Scanner sc = new Scanner(System.in);
+		nums = sc.nextLine().toCharArray();
+		numLen = nums.length;
+		promiseSet = new HashSet<>();
+
+		for (int i = 0; i < nums.length; i++) {
+			dfs(i, i, nums[i] + "", nums[i] + "");
+		}
+
+		System.out.println(promiseSet.size());
+	}
+
+	private static void dfs(int l, int r, String curr, String sequence) {
+		if (l == 0 && r == numLen - 1) {
+			promiseSet.add(sequence);
+			return;
+		}
+
+		if (0 <= l - 1) {
+			String addLeft = nums[l - 1] + curr;
+			dfs(l - 1, r, addLeft, sequence + addLeft);
+		}
+
+		if (r + 1 < numLen) {
+			String addRight = curr + nums[r + 1];
+			dfs(l, r + 1, addRight, sequence + addRight);
+		}
+
+	}
+
+}

--- a/JeonghakLee/Solution_2341_DDR.java
+++ b/JeonghakLee/Solution_2341_DDR.java
@@ -1,0 +1,49 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Solution_2341 {
+	static int[] sequence;
+	static int[][][] memo;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		sequence = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+		memo = new int[sequence.length - 1][5][5];
+
+		int minCost = dfs(0, 0, 0);
+
+		System.out.println(minCost);
+	}
+
+	private static int dfs(int curr, int left, int right) {
+		if (sequence[curr] == 0)
+			return 0;
+
+		if (memo[curr][left][right] != 0)
+			return memo[curr][left][right];
+
+		int moveLeft = dfs(curr + 1, sequence[curr], right) + getCost(left, sequence[curr]);
+		int moveRight = dfs(curr + 1, left, sequence[curr]) + getCost(right, sequence[curr]);
+
+		memo[curr][left][right] = Math.min(moveLeft, moveRight);
+
+		return memo[curr][left][right];
+	}
+
+	private static int getCost(int u, int v) {
+		if (u == 0) {
+			return 2;
+		}
+		if (u == v) {
+			return 1;
+		}
+		if (u - 1 == v || u + 1 == v) {
+			return 3;
+		}
+		return 4;
+	}
+}

--- a/JeonghakLee/Solution_5052_전화번호목록.java
+++ b/JeonghakLee/Solution_5052_전화번호목록.java
@@ -1,0 +1,69 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/*
+ 2
+3
+911
+97625999
+91125426
+5
+113
+12340
+123440
+12345
+98346
+ */
+public class Solution_5052 {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		StringBuilder result = new StringBuilder();
+
+		while (T-- > 0) {
+			int N = Integer.parseInt(br.readLine());
+			String[] numbers = new String[N];
+			boolean[] check = new boolean[11];
+			Set<String>[] prefixes = new HashSet[10 + 1];
+
+			for (int i = 0; i <= 10; i++) {
+				prefixes[i] = new HashSet<>();
+			}
+
+			for (int i = 0; i < N; i++) {
+				numbers[i] = br.readLine().trim();
+				check[numbers[i].length()] = true;
+				prefixes[numbers[i].length()].add(numbers[i]);
+			}
+
+			if (isPossible(prefixes, numbers, check)) {
+				result.append("YES\n");
+			} else {
+				result.append("NO\n");
+			}
+		}
+
+		System.out.println(result.toString());
+	}
+
+	private static boolean isPossible(Set<String>[] prefixes, String[] numbers, boolean[] check) {
+		for (String number : numbers) {
+			for (int i = 1; i <= 10; i++) {
+				if (number.length() < i)
+					break;
+				if (check[i]) {
+					String sub = number.substring(0, i);
+					if (i != number.length() && prefixes[i].contains(sub))
+						return false;
+				}
+			}
+		}
+
+		return true;
+	}
+}

--- a/JeonghakLee/Solution_7570_줄세우기.java
+++ b/JeonghakLee/Solution_7570_줄세우기.java
@@ -1,0 +1,43 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Solution_줄세우기 {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		int[] nums = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+		int[] LIS = new int[N + 1];
+		LIS[0] = 1;
+
+		int len = 0;
+		int idx = 0;
+		for (int i = 0; i < N; i++) {
+			// 현재 최대길이에 있는 값보다 큰 경우
+			if (nums[i] > LIS[len]) {
+				len += 1;
+				LIS[len] = nums[i];
+			} else {
+				idx = binarySearch(LIS, 0, len, nums[i]);
+				LIS[idx] = nums[i];
+			}
+		}
+		
+		System.out.println(N - len);
+	}
+
+	private static int binarySearch(int[] LIS, int left, int right, int key) {
+		int mid = 0;
+		while (left < right) {
+			mid = (left + right) / 2;
+			if (LIS[mid] < key) {
+				left = mid + 1;
+			} else {
+				right = mid;
+			}
+		}
+		return right;
+	}
+}


### PR DESCRIPTION
### 전화번호목록
#### 접근 방법
번호의 길이가 10이하로 주어지고 최대 10000개의 번호가 주어지므로 
완전탐색으로 풀어도 될 것이라고 생각했습니다.
#### 풀이방법
1. 길이를 인덱스로 하는 Set 배열을 만들어서 입력받은 번호를 길이에 따라 Set에 담습니다.
2. 입력받은 번호마다 길이 1~10 만큼 반복하면서 현재 번호의 길이와 다르고 Set에 현재 번호를 길이만큼 자른 접두어가 이미 있으면 NO, 모두 반복해도 없으면 YES가 되도록 했습니다.
#### 각 케이스별 시간복잡도 O(N)

### DDR
#### 접근 방법
처음에는 이전 두발의 상태에 따라 현재 오른발을 움직이는 경우 왼발을 움직이는 경우만 생각하여 반복문 한번으로 답을 구할 수 있다고 생각하여 틀렸습니다. 풀이방법이 쉽게 떠오르지 않아 미뤄두다 수업시간에 외판원 순회 문제를 DP를 활용하여 백트래킹 해보고 힌트를 얻어 풀 수 있었습니다.

#### 풀이방법
1. 밟아야 하는 곳을 저장한  배열의 idnex, 왼쪽 발의 위치, 오른쪽 발의 위치를 인덱스로 하여 최솟값을 저장할 3차원 배열을 선언합니다.
2. 백트래킹을 통해 현재 왼쪽발을 움직였을 때의 비용 , 오른쪽 발을 움직였을 떄의 비용 을 구하고 그중 최솟값을 memo 배열에 저장하고 return 합니다. 이때 이미 memo에 저장된 값이 있다면 탐색하지 않고 해당 값을 return하는 식으로 가지치기를 합니다.

### 줄세우기
#### 접근 방법
처음에는 뒤로 보내야 하는 수, 앞으로 보내야하는 수를 어떻게 계산해야 할까를 고민하며 방향을 잡지 못했습니다.
고민하다 어떤 수열을 불러도 1초 만에 최솟값을 말해주시는 @Pangpyo 님의 힌트를 통해 풀이방법을 깨닫게 되었습니다.

#### 풀이방법
결국 변하지 않는 순서의 최댓값을 찾으면 변해야하는 최소 움직임을 구할 수 있었습니다.
가장 긴 증가하는 부분수열의 길이를 이분탐색을 활용하여 구하고 전체 길이에서 빼는 식으로 답을 구했습니다.
#### 시간복잡도 O(NlogN)
