### PR TITLE
Wnsgml7267 / 4월 1주차

### DIFF
--- a/wnsgml7267/Solution_골드3_2342_DanceDanceRevolution.py
+++ b/wnsgml7267/Solution_골드3_2342_DanceDanceRevolution.py
@@ -1,0 +1,32 @@
+import sys
+sys.setrecursionlimit(10**9)
+input = sys.stdin.readline
+
+ddr = list(map(int,input().split()))
+dp = [[[-1]*5 for _ in range(5)] for _ in range(len(ddr))] # 각 지시사항까지 최소 힘
+
+# 같은 지점 이동 : 힘 1 
+# 0 => 이동 : 힘 2
+# 반대편 이동 : 힘 4
+# 인접 이동 : 힘 3
+def move(x, y):
+    if x == y:
+        return 1
+    elif x == 0:
+        return 2
+    elif abs(y-x) % 2 == 0:
+        return 4
+    else:
+        return 3
+
+def dy(n, l, r):
+    global dp
+    if n >= len(ddr) - 1: # 끝 지점 도달
+        return 0
+
+    if dp[n][l][r] != -1: # 방문한 곳
+        return dp[n][l][r]
+
+    dp[n][l][r] = min(dy(n+1, ddr[n], r) + move(l, ddr[n]), dy(n+1, l, ddr[n]) + move(r, ddr[n]))
+    return dp[n][l][r]
+print(dy(0, 0, 0))

--- a/wnsgml7267/Solution_골드3_7570_줄세우기.py
+++ b/wnsgml7267/Solution_골드3_7570_줄세우기.py
@@ -1,0 +1,10 @@
+from collections import defaultdict as dd
+n = int(input())
+arr = list(map(int,input().split()))
+dic = dd(int)
+for i in range(n):
+  t = arr[i] 
+  dic[t] = 1
+  if dic[t-1]: # 연속된 번호라면
+    dic[t] = dic[t-1] + 1
+print(n - max(dic.values()))

--- a/wnsgml7267/Solution_골드4_17255_N으로 만들기.py
+++ b/wnsgml7267/Solution_골드4_17255_N으로 만들기.py
@@ -1,0 +1,14 @@
+def dfs(string):
+    global answer
+    L = set(list(string))
+    if len(L) == 1:
+        answer+=1
+        return
+    else:
+        dfs(string[1:])
+        dfs(string[:-1])
+
+n = input()
+answer = 0
+dfs(n)
+print(answer)

--- a/wnsgml7267/Solution_골드4_5052_전화번호목록.py
+++ b/wnsgml7267/Solution_골드4_5052_전화번호목록.py
@@ -1,0 +1,18 @@
+import sys
+input = sys.stdin.readline
+t = int(input())
+for i in range(t):
+  answer = "YES"
+  n = int(input())
+  arr = []
+  st = set()
+  for j in range(n):
+    s = input().rstrip()
+    arr.append(s)
+    st.add(s)
+  for j in range(len(arr)):
+    for k in range(1, len(arr[j])):
+      if arr[j][:k] in st:
+        answer = "NO"
+        break
+  print(answer)


### PR DESCRIPTION
# 4월 1주차
## [BOJ] 2342 Dance Dance Revolution
* 4달 전에도 못 풀어서 풀이를 본 문제였으며 알고리즘 분류가 dp인 것을 알았음에도 불구하고 해결책이 잘 떠오르지 않아 풀이를 참고하게 되었고 구현 순서를 나열해보며 이해를 해봤다.. 

- 구현 순서
1. 왼발, 오른발 각각 0~4 중에 이동할 수 있으므로 (5X5) 행렬을 만든다.
2. 모든 지시사항의 경우의 수를 구하기 위해 (len(ddr) x 5 x 5) 3차원 행렬을 만든다. (dp)
3. 위에서 정의한 각 이동 형태마다 들어가는 힘에 대해 함수로 정의하여 해당하는 힘을 리턴한다. (def move)
4. 다음 지시사항마다 왼발을 이동했을 때, 오른발을 이동했을 때의 최솟값을 메모제이션을 통해 시간 복잡도를 줄이면서 dp에 저장하는 함수를 만든다. (def dy)
5. 4번 함수(def dy)의 파라미터에 제일 처음 위치(0, 0, 0)부터 넣어 최종적으로 리턴된 값을 출력한다.(print(dy(0,0,0)))

<br>

## [BOJ] 7570 줄 세우기
부족한 테스트 케이스로 인해 어떤 방식으로 순서대로 줄을 서는지 고민하던 찰나에 "ㅁㅁ표"님께서 추가적으로 2가지 테스트 케이스를 더 알려주신 덕분에 그리디적인 해결 방법을 찾을 수 있었다. 그러나, 해당 방법을 어떠한 알고리즘을 통해 나열해야 하는지 고민하는 데에 시간을 조금 할애했다. 

왜냐하면, 주어진 범위가 100만이었기 때문이었다. 이러한 비슷한 문제로 "가장 긴 증가하는 부분 수열"이라는 문제가 떠올라 해당 방법으로 dp를 이용하여 1씩 순서대로 증가하는 방법을 찾아 구현하는 방법을 생각해냈지만, 이 방법도 결국 2중 for문을 돌려야했다.

고민하던 찰나에 무조건 1씩 증가한다는 것을 생각해서 딕셔너리에 저장하여 해당 key보다 1낮은 key가 존재하는지 여부를 판단하여 문제를 해결할 수 있었다.

<br>

## [BOJ]5052_전화번호 목록
입력받은 모든 전화번호 자리수를 슬라이싱 완탐하여 같은 번호가 있어 번호가 눌러진다면 NO 출력

완탐한 이유는 전화번호 범위가 10000이며, 전화번호 최대 길이는 10자리 이므로, 100000밖에 되지 않기 때문에 이 방법을 선택했다.

범위를 더 줄임과 동시에 본래 문제가 요구하던 알고리즘은 정렬을 통해 전화번호 길이 순서대로 접두어를 찾는다면 더 빠른 시간 내에 문제를 해결할 수 있다는 점을 알게 되었다.

<br>

## [BOJ]17255_N으로 만들기
겉보기엔 짧은 코드지만, 이렇게 생각하기가 까다로웠던 문제였다. ( 해결 방법을 못 찾아 결국 풀이를 참고하였다. )

처음 헷갈렸던 부분은 n의 범위가 천만 이었기 때문에 N^2의 시간 복잡도를 가지는 알고리즘으로 구현한다면 시간 초과가 난다고 이상한 생각했기 때문이다. 그러나, 각 자리 수를 비교하는 것이었기 때문에 10000000이라고 해도 총 8 자리 수 밖에 되지 않았다. 이 부분 때문에 풀이를 보게 되었다..

그러므로 집합과 dfs(백트래킹?)를 이용하여 문제를 해결할 수 있었다.

해당 로직은 처음 입력 받은 n의 수에서 한 자리씩 양쪽으로 줄여가며 중복인 경우를 제거하기 위해 set을 사용하여 한 자리수가 된다면 방법의 수(answer)를 증가 시켜주어 문제를 해결하는 것을 보여준다.