### PR TITLE
Pangpyo / 4월 2주차

### DIFF
--- a/Pangpyo/Solution_14621_나만안되는연애.py
+++ b/Pangpyo/Solution_14621_나만안되는연애.py
@@ -11,7 +11,6 @@ def solution() :
 
     parent = [-1] * (N + 1)
 
-
     def find(x):
         if parent[x] < 0:
             return x

--- a/Pangpyo/Solution_17298_오큰수.py
+++ b/Pangpyo/Solution_17298_오큰수.py
@@ -15,6 +15,5 @@ def solution() :
 
     return answer
 
-
 if __name__ == "__main__": 
     print(*solution())

--- a/Pangpyo/Solution_22942_데이터체커.java
+++ b/Pangpyo/Solution_22942_데이터체커.java
@@ -1,0 +1,61 @@
+package algostudy;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class Solution_22942_데이터체커 {
+	public static void main(String[] args) throws Exception{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		int N = Integer.parseInt(br.readLine());
+		int[][] C = new int[N][2];
+		int x, r;
+		for (int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			x = Integer.parseInt(st.nextToken());
+			r = Integer.parseInt(st.nextToken());
+			C[i][0] = x-r;
+			C[i][1] = x+r;
+		}
+		Arrays.sort(C, new Comparator<int[]>() {
+			@Override
+			public int compare(int[] o1, int[] o2) {
+				if (o1[0] == o2[0]) return o1[1]-o2[1];
+				return o1[0] - o2[0];
+			}
+		});
+		Stack<int[]> stack = new Stack<>();
+		int a, b, na, nb;
+		String ans = "YES";
+		for(int i=0; i<N; i++) {
+			while (true) {
+				if (stack.isEmpty()) {
+					stack.add(C[i]);
+					break;
+				}
+				else {
+					a = stack.peek()[0];
+					b = stack.peek()[1];
+					na = C[i][0];
+					nb = C[i][1];
+					if (a < na && nb < b) {
+						stack.add(C[i]);
+						break;
+					}
+					else if ((na < b && b < nb) || na == a || nb == b) {
+						ans = "NO";
+						break;
+					}
+					else {
+						stack.pop();
+					}
+				}
+			}
+		}
+		System.out.println(ans);
+	}
+}

--- a/Pangpyo/Solution_4195_친구네트워크.py
+++ b/Pangpyo/Solution_4195_친구네트워크.py
@@ -12,7 +12,6 @@ def solution() :
             parent[x] = y
             return y
 
-
     def union(x, y):
         x = find(x)
         y = find(y)


### PR DESCRIPTION
# 4월 2주차
---
## [BOJ]나만안되는연애/G3/40
* 다익스트라와 MST를 의심했고, 다익스트라를 먼저 시도했지만 틀려서 반례를 생각해보니 당연히 안되는 경우가 있었다. 그래서 크루스칼 알고리즘을 통해 조건에 맞을 때만 간선을 연결해서 해결 할 수 있었다.
* 시간 복잡도 : O(ElogE) (간선 정렬에 가장 큰 시간 소모)\
* 사용 알고리즘 : 최소 스패닝 트리

## [BOJ]오큰수/G4/30m
* 여러 아이디어를 생각했으나, 결국 스택을 사용해야겠다는 점만 떠올렸다면 그 다음부턴 수월하게 풀 수 있었다. 스택에 인덱스를 저장해서 스택의 가장 앞에 저장된 인덱스를 확인하면서 답을 저장했다.
* 시간 복잡도 : O(N)
* 사용 알고리즘 : 스택

## [BOJ]데이터체커/G4/30m
* 기하 문제인가? 싶었는데 원이 모두 일직선 상에 있기에 괄호 문제로 치환 할 수 있겠다고 생각했다. 이전에 풀었던 곡선자르기와 유사한 방식으로 해결 할 수 있었다. 원의 외접과 내접같은 부분에 대해 크게 생각하지 않고 괄호라고 생각하면 좀 더 쉽게 풀린다.
* 시간 복잡도 : O(NlogN) (정렬에 드는 시간이 가장 크다)
* 사용 알고리즘 : 정렬, 스택

## [BOJ]친구네트워크/G2/100m\
* 유니온 파인드를 사용해야 한다는 점까지는 떠올리기가 쉬웠다. 하지만 일반적인 유니온 파인드의 방식에서 parent의 각 원소를 자기 자신으로 초기화 시키는 경우에는, 해당 원소가 속한 집합의 원소 개수를 바로바로 알기가 어려워 이 부분을 O(1)로 조회하는 방법을 생각해야 했다. 그래서 찾아낸 방법이 parent의 각 원소를 -1로 초기화 한 후, 부모 인덱스에 자신의 값을 더해주는 방식이다. 이 방식을 쓸 경우 부모에 속한 원소의 개수를 O(1)로 조회 할 수 있었다.
* 시간 복잡도 : O(N)? 유니온 파인드 한번의 시간복잡도는 거의 상수에 가깝다고 들었다..
* 사용 알고리즘 : 해쉬, 유니온 파인드