### PR TITLE
Wnsgml7267 / 4월 2주차

### DIFF
--- a/wnsgml7267/Soltion_골드4_22942_데이터체커.py
+++ b/wnsgml7267/Soltion_골드4_22942_데이터체커.py
@@ -1,0 +1,22 @@
+import sys
+input = sys.stdin.readline
+n = int(input())
+v = [-1 for _ in range(2000001)]
+stack = [-1]
+
+for i in range(n):
+    a, b = map(int,input().split())
+    v[a-b], v[a+b] = i, i
+
+for i in range(1000001, 2000001): # 음수부터 시작
+    if v[i] != -1:
+        if stack[-1] == v[i]: stack.pop()
+        else: stack.append(v[i])
+
+for i in range(1000001): # 0부터 시작
+    if v[i] != -1:
+        if stack[-1] == v[i]: stack.pop()            
+        else: stack.append(v[i])
+            
+if len(stack)==1: print("YES")
+else: print("NO")

--- a/wnsgml7267/Solution_골드2_4195_친구네트워크.py
+++ b/wnsgml7267/Solution_골드2_4195_친구네트워크.py
@@ -1,0 +1,33 @@
+import sys
+input = sys.stdin.readline
+
+def find(a): # (경로 압축) 부모 노드 구하기
+  if a != parents[a]:
+    parents[a] = find(parents[a])
+  return parents[a]
+
+def union(a, b):
+  aRoot = find(a)
+  bRoot = find(b)
+  if aRoot != bRoot:
+    parents[bRoot] = aRoot
+    cnt[aRoot] += cnt[bRoot] # aRoot에 친구 수 합치기
+
+for _ in range(int(input())):
+  parents = {} # 부모 노드 구하기
+  cnt = {} # 부모와 친구 수 구하기
+  for i in range(int(input())):
+    a, b = input().rstrip().split()
+    if a not in parents:
+      parents[a] = a
+      cnt[a] = 1
+    if b not in parents:
+      parents[b] = b
+      cnt[b] = 1
+
+    union(a, b)
+
+    print(cnt[find(a)]) # a의 부모 노드의 친구 수 출력
+      
+
+  

--- a/wnsgml7267/Solution_골드3_14621_나만안되는연애.py
+++ b/wnsgml7267/Solution_골드3_14621_나만안되는연애.py
@@ -1,0 +1,37 @@
+from heapq import heappop, heappush
+
+def find(x):
+    if x != parents[x]:
+        parents[x] = find(parents[x])
+    return parents[x]
+
+def union(x, y):
+    aRoot = find(x)
+    bRoot = find(y)
+    parents[bRoot] = aRoot
+    
+n, m = map(int,input().split())
+uni = [0] + list(input().split())
+heap = [] # 가중치 + 좌표
+total = 0 # 최소 가중치 합
+parents = [i for i in range(n+1)] # 루트 노드
+visited = [False for _ in range(n+1)] # 방문 체크
+
+for i in range(m):
+    u, v, cost = map(int,input().split())
+    heappush(heap, (cost, u, v))
+
+while(heap):
+    cost, x, y = heappop(heap)
+    if find(x) != find(y) and uni[x] != uni[y]:
+        visited[x], visited[y] = True, True
+        union(x, y)
+        total += cost
+
+if visited.count(False) == 1: # 모두 방문
+    print(total)
+else:
+    print(-1)
+        
+
+

--- a/wnsgml7267/Solution_골드4_17298_오큰수.py
+++ b/wnsgml7267/Solution_골드4_17298_오큰수.py
@@ -1,0 +1,20 @@
+n = int(input())
+arr = list(map(int,input().split()))
+answer = [-1 for _ in range(n)]
+stack = []
+for i in range(n-2, -1, -1):
+    if arr[i] < arr[i+1] and arr[i] < answer[i+1]: # 둘 다 클 때
+      answer[i] = arr[i+1]
+      stack.append(answer[i+1]) # 이 전에 있던 큰 수는 스택에 담아둠
+    elif arr[i] < arr[i+1]: # 바로 뒤에 있는 값이 크면
+       answer[i] = arr[i+1]
+    elif arr[i] < answer[i+1]: # 이전에 있던 값중 큰 수
+      answer[i] = answer[i+1]
+    else: # 둘 다 작을 때
+      while(stack): # 스택에서 더 큰 수가 있는지 찾기
+         p = stack.pop()
+         if arr[i] < p:
+            answer[i] = p
+            break
+       
+print(*answer)


### PR DESCRIPTION
# 4월 2주차
---
## [BOJ]나만안되는연애/G3/30m

- 접근 방법

주어진 문제에 나온 그림을 보고 싸이클이 존재하지 않는 최소 가중치를 구한다는 것을 바로 알 수 있어서 최소 스패닝 트리를 이용하면 된다는 것을 알 수 있었다.

- 풀이 방법

#MST(Minimum Spanning Tree) - 최소 신장(스패닝) 트리
#Kruskal Algorithm(크루스칼 알고리즘으로 구현)

1. 주어진 모든 간선 정보에 대해 간선 비용이 낮은 순서로 뽑기 위해 우선순위 큐 사용
2. 정렬된 간선 정보를 하나씩 확인하면서 현재의 간선이 노드들 간의 사이클을 발생시키는지 확인
3. 만약 사이클이 발생하지 않고, 성별이 다른 대학이면 최소 신장 트리에 포함시키고 가중치 누적
4. 연산이 끝난 후 최종적으로, 모든 대학을 방문했다면 누적한 가중치(total) 출력. 아니면 -1 출력



## [BOJ]오큰수/G4/35m

- 접근 방법

10분만에 처음 생각했던 방식은 탑다운 방식으로 두 가지의 경우를 비교하여 오큰수를 구해주면 된다고 생각하였다.

1. 바로 뒤에 있는 값

2. 이전에 있던 값 중 큰 수

문제가 쉽네? 라고 생각을 하였고, 테스트 케이스도 다 맞아서 제출했더니 바로 틀렸다..

반례를 찾아보니 

4

3 1 2 4일 경우, 정답이 4 2 4 -1이 나와야 하지만, 내 코드는 -1 2 4 -1이 나왔다.

그 이유는 해당 arr 위치에 무조건 이 전에 있던 큰 수를 차례대로만 저장해둔다면 그 전전~ 전전전~ 에 있던 큰 값을 가져올 수가 없었기 때문이다.

이 방법을 해결하기 위해서 스택을 사용하여 해결했다.

- 풀이 방법

탑다운 방식

1. 바로 뒤에 있는 값

2. 이전에 있던 값 중 큰 수

스택을 사용하여 1, 2번의 경우가 현재 값보다 둘 다 클 경우에는 2번(이전에 있던 큰 수)을 스택에 차례대로 저장해둔 후, 현재 값(arr[i])이 1,2번의 경우보다 작을 경우 스택에서 저장해둔 값들을 차례대로 빼주어 현재 값보다 큰 값이 있다면 그 값을 2번에 저장한다. 

이 저장 방식으로는 스택에서 무조건 내림차순으로 저장되기 때문에 따로 건드릴 필요가 없어서 pop으로 차례대로 빼주며 찾으면 된다.

 
// 추가적으로, 더 쉬운 방법이 있을까 하고 찾아봤는데 더 쉬운 풀이가 있었다.

간단한 해결 방법은 바텀업 방식으로 스택에 이전 인덱스를 저장하여 현재값과 비교하여 오큰수를 찾는 쉬운 방법을 알 수 있었다.


## [BOJ]데이터체커/G4/1h

- 접근 방법

처음 문제를 보면 원의 내접, 외접, 두 점 사이의 거리 등의 수식이 주어져서 수학 문제인가 싶었지만, 문제를 다 읽고보니 x 좌표에 원점을 중심으로 원이 겹치지 않게 구분하는 문제임을 알 수 있었다.

해당 문제를 해결하려면 하나의 원을 기준으로 다른 원이 아예 바깥 쪽에 위치하거나, 안쪽에 위치해야 하므로 원의 왼쪽 끝 x좌표와 오른쪽 끝 x좌표에 다른 원이 지나가면 안된다는 점을 알 수 있었다.

결국 이렇게 구현하려면 원의 왼쪽 끝, 오른쪽 끝 x좌표의 정보를 알고 있어야 했다. 그래서 각 원의 양쪽 지점을 동일한 수로 지정해주어 같은 원인지 다른 원인지 구분해주었다.
구분하고 보니 프로그래머스에서 풀어보았던 괄호 문제와 비슷한 그림이 나와서 스택을 생각해낼 수 있었다.

ex ) 1 0 0 1 2 0 2 3 0 3
리스트에 각각의 1번 원, 2번 원, 3번 원 양쪽의 끝 점을 표시

- 해결 방법 ( 소요 시간 : 1시간 )

스택을 이용하여 풀기 위해 리스트에 각각의 원 번호를 표시해주었고, 원이 겹치지 않고 잘 그려졌는지 체크하기 위해 x 좌표의 제일 처음 올 수 있는 지점인 -1,000,000지점부터 순서대로 확인하였다. 주의해야 할 점은 x 좌표가 음수인 -1,000,000부터 있을 수 있으므로 리스트의 인덱스가 음수로 넘어갈 경우 맨 뒤 인덱스부터 탐색한다는 것을 이용했다.

리스트의 1,000,001인덱스(-1,000,000)부터 2,000,000인덱스(-1) 까지 순서대로 본 후, 리스트의 0인덱스(0)부터 1,000,000인덱스(1,000,000)까지 for문을 돌려서 -1,000,000 ~ 1,000,000 범위의 x 좌표를 확인했다. 

스택에서의 마지막 값이 탐색한 값과 같을 경우 원이 겹치지 않고 정상적으로 위치한 것이므로 스택에서 빼준다.
최종적으로, 스택을 확인했을 때 스택에 값이 남아있을 경우 겹치는 원이 있다는 것을 알 수 있다.


## [BOJ]친구네트워크/G2/2h

- 접근방법

문제의 제목으로 유니온 파인드 알고리즘을 사용해야한다는 것을 눈치챌 수 있었다. 그러나, 정수가 아닌 문자열로 이루어져 있어서 set과 set의 union메소드를 사용하면 혹시 되지 않을까 하는 마음에 시도해보았다.

그러나, 제출 시 38%에서 메모리 초과가 났다. 결국 유니온 파인드는 사용해야하는 것을 깨닫고, 유니온 파인드로 해결할 방법을 시도했다.

입력값이 문자열로 주어져 있어서 find()함수로 부모 노드를 찾는 것을 딕셔너리에 문자열로 저장하여 찾을 수는 있었는데, 친구의 수를 시간 초과없이 어떻게 구해야할지 감이 잡히지 않아서 이걸 해결하려면 딕셔너리의 value값을 정수로 해야하는데 또 부모 노드를 찾으려면 문자열로 해야해서 머리가 복잡해져 결국 풀이를 보게 되었다.

풀이를 보니 내가 고민했던 두 가지가 다 필요했다.

- 해결방법 (소요 시간 : 2h 이상 / 풀이 참고함 )

유니온 파인드
parents = {}  부모 노드 구하기 : value값을 문자열로 한 딕셔너리
cnt = {} 친구 수 구하기 : value값을 정수로 한 딕셔너리

find함수로 경로 압축하여 부모 노드를 구하고, 입력받은 두 문자열을 union함수로 합친다.

합치는 방법은 서로의 부모 노드가 다르면 두 번째 입력받은 친구(b)의 부모노드(bRoot)에 부모 노드를 첫 번째 입력받은 친구(a)의 부모노드(aRoot)로 바꿔준다.

추가적으로, aRoot에 친구 수 bRoot의 친구 수를 합친다.

마지막으로 입력받은 첫 번째 친구(a)의 부모노드(find(a))의 친구 수(cnt(find(a))를 출력하면 된다.