### PR TITLE
JeonghakLee / 4월 4주차

### DIFF
--- a/JeonghakLee/Solution_16936_나3곱2.java
+++ b/JeonghakLee/Solution_16936_나3곱2.java
@@ -1,0 +1,64 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class Solution_16936_나3곱2 {
+
+	static long[] answer;
+	static int N;
+	static Set<Long> set;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		List<Long> list = new ArrayList<>();
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		for (int i = 0; i < N; i++) {
+			list.add(Long.parseLong(st.nextToken()));
+		}
+
+		answer = new long[N];
+
+		set = new HashSet<Long>(list);
+
+		for (int i = 0; i < N; i++) {
+			answer[0] = list.get(i);
+			if (isPossible(list.get(i), 1))
+				break;
+		}
+
+	}
+
+	private static boolean isPossible(long x, int cnt) {
+
+		if (cnt == N) {
+			StringBuilder sb = new StringBuilder();
+			for (int i = 0; i < N; i++) {
+				sb.append(answer[i] + " ");
+			}
+			
+			System.out.println(sb.toString().trim());
+			System.exit(0);
+			return true;
+		}
+
+		if (x % 3 == 0 && set.contains(x / 3)) {
+			answer[cnt] = x / 3;
+			isPossible(x / 3, cnt + 1);
+		}
+
+		if (set.contains(x * 2)) {
+			answer[cnt] = x * 2;
+			isPossible(x * 2, cnt + 1);
+		}
+
+		return false;
+	}
+}

--- a/JeonghakLee/Solution_9576_책나눠주기.java
+++ b/JeonghakLee/Solution_9576_책나눠주기.java
@@ -1,0 +1,56 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Solution_9576_책나눠주기 {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		int T = Integer.parseInt(br.readLine());
+		StringBuilder result = new StringBuilder();
+
+		while (T-- > 0) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+
+			int N = Integer.parseInt(st.nextToken());
+			int M = Integer.parseInt(st.nextToken());
+
+			PriorityQueue<int[]> pq = new PriorityQueue<>((o1, o2) -> {
+				if (o1[1] == o2[1]) {
+					return o1[0] - o2[0];
+				}
+				return o1[1] - o2[1];
+			});
+
+			for (int i = 0; i < M; i++) {
+				st = new StringTokenizer(br.readLine());
+				int a = Integer.parseInt(st.nextToken());
+				int b = Integer.parseInt(st.nextToken());
+
+				pq.offer(new int[] { a, b });
+			}
+
+			int answer = 0;
+			boolean[] visit = new boolean[N + 1];
+
+			while (!pq.isEmpty()) {
+				int[] peek = pq.poll();
+
+				for (int i = peek[0]; i <= peek[1]; i++) {
+					if (!visit[i]) {
+						visit[i] = true;
+						answer++;
+						break;
+					}
+				}
+			}
+
+			result.append(answer + "\n");
+		}
+
+		System.out.println(result);
+	}
+}

--- a/JeonghakLee/Solution_가장큰수.java
+++ b/JeonghakLee/Solution_가장큰수.java
@@ -1,0 +1,34 @@
+package programmers;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class Solution_가장큰수 {
+	public String solution(int[] numbers) {
+		String answer = "";
+		int sum = 0;
+
+		for (int num : numbers) {
+			sum += num;
+		}
+
+		if (sum == 0)
+			return "0";
+
+		List<String> strList = Arrays.stream(numbers).boxed().map(i -> String.valueOf(i)).collect(Collectors.toList());
+
+		Collections.sort(strList, (o1, o2) -> {
+			String t1 = o1 + o2;
+			String t2 = o2 + o1;
+			return t1.compareTo(t2);
+		});
+
+		for (String str : strList) {
+			answer = str + answer;
+		}
+
+		return answer;
+	}
+}

--- a/JeonghakLee/Solution_입국심사.java
+++ b/JeonghakLee/Solution_입국심사.java
@@ -1,0 +1,47 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Solution_입국심사 {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N, M;
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+
+		int[] judge = new int[N];
+		for (int i = 0; i < N; i++)
+			judge[i] = Integer.parseInt(br.readLine());
+
+		// 이분 탐색
+		Arrays.sort(judge);
+		long start = 0, end = (long) Math.pow(10, 18), mid = 0;
+
+		while (start < end) {
+			mid = (start + end) / 2;
+			if (getPassedCnt(judge, mid, M) < M) {
+				start = mid + 1;
+			} else {
+				end = mid;
+			}
+		}
+
+		System.out.println(end);
+	}
+
+	private static long getPassedCnt(int[] judge, long time, int M) {
+		long result = 0;
+		for (int i = 0; i < judge.length; i++) {
+			result += time / judge[i];
+			if (result > M)
+				break;
+		}
+		return result;
+	}
+
+}


### PR DESCRIPTION
## 입국심사
#### 접근방법
- 처음에 그리디한 방법을 생각해보았는데 그래도 입력이 너무커서 좀 더 고민하다 이분탐색을 떠올렸다. 
- 입력 크기를 봤을 때 당연할 수도 있었는데 꽤 오래 걸렸던 것 같다.


#### 풀이방법
- 시간을 매개 변수로 이분 탐색을 진행하였다.
- 탐색 조건은 현재 시간에 입국심사를 통과하는 승객 수이고 이 승객 수가 M이 될 때의 시간을 구한다.
- 이분 탐색 시 현재 time에 통과하는 사람 수를 계산하는 과정에서 최대 10^9 * 10*9 일 수 밖에 없다는 생각에 갇혀서 틀렸었다.
    - 최대 값에 상관없이 N의 최대 크기 * 10^9 * 10*9 까지 될 수 있어서 M을 넘어가면 break 하도록 처리했다.

시간 복잡도 O(log(N))

## 나3 곱2
#### 접근방법
- 문제를 보고 백트래킹으로 풀이할 수 있음을 직감했다.
- 어떤 수에 계속해서 2를 곱하거나 3을 나누는 것을 반복해도 겹치는 수가 나오지 않음을 이용해서 백트래킹 조건에 HashSet을 사용했다.
- answer 배열을 static 변수로 두고 답을 찾은 후에 남은 재귀들을 처리하지 않아서 틀렸었다.

#### 풀이방법
- 주어진 수 배열을 HashSet에 담아둔다.
- 주어진 수들을 반복하며 시작 수로 두고 나3곱2를 만족하는 수열을 찾는 dfs를 수행한다.
- 현재수가 3으로 나누어지고 나누어진 값이 HashSet에 있으면 현재 수를 3으로 나누고 다음 재귀를 수행한다.
- 현재수에 2를 곱한 값이 hashSet에 있으면  현재 수에 2를 곱하고 다음 재귀를 수행한다.
- 재귀문의 depth가 N이되면 나3곱2가 완성되므로 종료한다.

시간 복잡도 O(N^2)

## 책 나눠주기
#### 접근방법
- 처음에 그리디하게 해결할 수 있겠다는 생각이 들었다.
- `회의실 배정`문제와 비슷하다고 생각하여 b를 우선으로 오름차순으로 정렬하고 같으면 a를 기준으로 오름차순으로 정렬하도록 우선순위 큐에 담아두었다. 
- 그리고 1 ~ N만큼 반복하며 현재 peek의 범위안에 포함되면 책을 주는 식으로 풀이했다.
- 그런데 이 풀이에는 반례가 존재했다. (@Pangpyo 님이 반례를 제시해주셨다...그저..)
- a b가 (2,2), (1, 3), (3, 3) 이렇게 입력이 들어올 때 1번 책은 나눠줄 수 없는 풀이였다.
- 그래서 a, b 가 (1, 3)일 때 1번 책을 줄 수 있도록 현재 빌려준 책을 표시하는 visit 배열을 두고 a ~ b 범위에서 가장 낮은 번호의 책을 빌려주는 식으로 풀이를 수정했다.

####  풀이방법
- b 오름차순, b가 같으면 a 오름차순으로 정렬하는 우선순위 큐 생성
- 우선순위큐가 빌 때 까지 poll 하면서 현재 poll한 값의 a~b 중 visit 하지 않은 가장 낮은 번호의 책이 있으면 해당값을 visit하고 answer 증가

시간 복잡도 O(N logn(N))

## 가장큰 수
#### 접근방법
- 가장 큰 수의 기준을 잘 세우는 것이 중요했다.
- 정수로 봤을 때  9 < 100 이지만 문제의 수를 만드는 방식으로 하면 1009 < 9100 이므로 문자열 기준으로 정렬해야 한다고 생각했다.
- 3 ~ 4개의 정렬기준을 세워보며 시도해도 반례가 계속해서 나왔다..(자리수가 다르면 0을 채우는 방법, 길이가 더 짧은 수의 끝 값과 긴 수의 앞 값을 비교하는 방법 등)
- 그래서 결국 힌트를 봤다.

#### 풀이방법
- 정렬 기준은 생각해보면 정말 간단했다.
- 두 문자열(수)의 순서를 바꾸어 더해서 나온 문자열을 정렬기준으로 삼으면 해결되는 문제였다(물론 다른 풀이도 있음)
- ex) 3, 301  3301 vs 3013 

시간 복잡도 O(N logn(N))