### PR TITLE
Pangpyo / 5월 2주차

### DIFF
--- a/Pangpyo/Solution_1188_음식평론가.py
+++ b/Pangpyo/Solution_1188_음식평론가.py
@@ -1,0 +1,6 @@
+import math
+
+N, M = map(int, input().split())
+N %= M
+gcd = math.gcd(N, M)
+print((M // gcd - 1) * gcd)

--- a/Pangpyo/Solution_12764_싸지방에간준하.java
+++ b/Pangpyo/Solution_12764_싸지방에간준하.java
@@ -1,0 +1,77 @@
+package solve;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Solution_12764_싸지방에간준하 {
+
+	static class Seat implements Comparable<Seat> {
+		int n, t;
+
+		public Seat(int n, int t) {
+			this.n = n;
+			this.t = t;
+		}
+
+		@Override
+		public int compareTo(Seat o) {
+			return this.t - o.t;
+		}
+	}
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		int N = Integer.parseInt(br.readLine());
+		int n = 0;
+
+		int[][] peaple = new int[N][2];
+
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			peaple[i][0] = Integer.parseInt(st.nextToken());
+			peaple[i][1] = Integer.parseInt(st.nextToken());
+		}
+
+		Arrays.sort(peaple, new Comparator<int[]>() {
+			@Override
+			public int compare(int[] o1, int[] o2) {
+				if (o1[0] == o2[0])
+					return o1[1] - o2[1];
+				return o1[0] - o2[0];
+			}
+		});
+		int[] com = new int[N];
+		PriorityQueue<Seat> useSeats = new PriorityQueue<>();
+		PriorityQueue<Seat> emptySeats = new PriorityQueue<>(new Comparator<Seat>() {
+			@Override
+			public int compare(Seat o1, Seat o2) {
+				return o1.n - o2.n;
+			}
+		});
+		useSeats.offer(new Seat(0, -1));
+		for (int[] person:peaple) {
+			while (!useSeats.isEmpty() && useSeats.peek().t <= person[0]) {
+				emptySeats.offer(useSeats.poll());
+			}
+			if (!emptySeats.isEmpty() && emptySeats.peek().t < person[0]) {
+				Seat seat = emptySeats.poll();
+				seat.t = person[1];
+				com[seat.n]++;
+				useSeats.offer(seat);
+			}else {
+				useSeats.offer(new Seat(++n, person[1]));
+				com[n]++;
+			}
+		}
+		System.out.println(n+1);
+		for (int i=0; i<=n; i++) {
+			System.out.print(com[i]+" ");
+		}
+
+	}
+}

--- a/Pangpyo/Solution_1520_내리막길.py
+++ b/Pangpyo/Solution_1520_내리막길.py
@@ -1,0 +1,39 @@
+import sys
+
+
+input = sys.stdin.readline
+
+sys.setrecursionlimit(10**5)
+
+N, M = map(int, input().split())
+
+L = [list(map(int, input().split())) for _ in range(N)]
+
+
+dx = [-1, 0, 1, 0]
+dy = [0, 1, 0, -1]
+D = [[0] * M for _ in range(N)]
+D[0][0] = 1
+
+visit = [[0] * M for _ in range(N)]
+
+
+def dfs(x, y):
+    v = D[x][y]
+    if v:
+        return v
+    for i in range(4):
+        nx = x + dx[i]
+        ny = y + dy[i]
+        if nx >= N or nx < 0 or ny >= M or ny < 0:
+            continue
+        if visit[x][y]:
+            continue
+        if L[nx][ny] > L[x][y]:
+            v += dfs(nx, ny)
+    D[x][y] = v
+    visit[x][y] = 1
+    return v
+
+
+print(dfs(N - 1, M - 1))

--- a/Pangpyo/Solution_1937_욕심쟁이판다.java
+++ b/Pangpyo/Solution_1937_욕심쟁이판다.java
@@ -1,0 +1,47 @@
+package solve;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Solution_1937_욕심쟁이판다 {
+	
+	static int N;
+	static int[][] map;
+	static int[][] visit;
+	static int[] dx = {-1, 0, 1, 0};
+	static int[] dy = {0, 1, 0, -1};
+	
+	static int dfs(int x, int y) {
+		if (visit[x][y] > 0) return visit[x][y]; 
+		int nx, ny;
+		visit[x][y] = 1;
+		for (int i=0; i<4; i++) {
+			nx = x + dx[i];
+			ny = y + dy[i];
+			if (nx >= N || nx < 0 || ny >= N || ny < 0) continue;
+			if (map[nx][ny] <= map[x][y]) continue; 
+			visit[x][y] = Math.max(visit[x][y], dfs(nx, ny)+1);
+		}
+		return visit[x][y];
+	}
+	
+	public static void main(String[] args) throws Exception{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		
+		N = Integer.parseInt(br.readLine());
+		map = new int[N][N];
+		visit = new int[N][N];
+		
+		for (int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j=0; j<N; j++) map[i][j] = Integer.parseInt(st.nextToken());
+		}
+		int ans = 0;
+		for (int i=0; i<N; i++) {
+			for (int j=0; j<N; j++)  ans = Math.max(ans, dfs(i, j));
+		}
+		System.out.println(ans);
+	}
+}


### PR DESCRIPTION
## [BOJ]음식평론가/G4/60m
* 그리디를 생각했지만 그렇지 않았고, 직접 막대기를 그리고 잘라가면서 최대공야수와 관련이 있다는 것을 깨달았다. 우선 n을 m으로 나눈 나머지만을 생각한다. 이후에는 n 과 m을 두 수의 최대 공약수로 나눈 뒤, 여러 케이스에 대해 직접 막대들을 잘라봤는데 항상 m-1만큼의 칼질이 필요하다는 것을 깨달았다. 
* 사용 알고리즘 : 수학, 애드혹?
* 시간 복잡도 : O(logn) (최대공약수를 구하는 과정)

## [BOJ]싸지방에 간 준하/G3/20m
* 우선순위 큐를 사용해야겠다는 것을 빠르게 깨달을 수 있었다. 사용 시간이 빠른 순으로 정렬을 한 뒤, 사용중인 자리와 빈 자리를 각각 조건에 맞게 pq를 사용해서 해결 할 수 있었다.
* 사용 알고리즘 : 그리디, 우선순위 큐
* 시간 복잡도 : O(nlogn)

## [BOJ]욕심쟁이 판다/G3/20m
* 모든 경우에 대해 dfs를 하다보면 시간초과가 난다. 그 것을 방지하기 위해, 각 정점에 방문 할 수 있는 최대 경우의 수를 저장해서 방문 한 점의 경우 바로 최대값만 리턴하는 식으로 문제를 해결 할 수 있었다. 요즘 코테에도 많이 나오는 유형인듯.
* 사용 알고리즘 : dfs, dp
* 시간 복잡도 : ??

## [BOJ]내리막길/G3/20m
* 욕심쟁이 판다와 비슷한 문제. 욕심쟁이 판다가 최대값을 본다면, 이 문제는 총 경우의 수를 구하는 문제이다.
* 사용 알고리즘 : dfs, dp
* 시간 복잡도 : ??